### PR TITLE
Install script fix

### DIFF
--- a/setup/functions
+++ b/setup/functions
@@ -200,8 +200,8 @@ certs:
     
     # Setup MySQL user
     mysql -u root -e "CREATE USER '$productId'@'localhost' IDENTIFIED BY '$mysqlPassword';"
-    mysql -u root -e "GRANT ALL PRIVILEGES ON $productId.* TO '$productId'@'localhost';"
-    mysql -u $productId --password="$mysqlPassword" -e "CREATE database $productId;"
+    mysql -u root -e "GRANT ALL PRIVILEGES ON \`$productId\`.* TO '$productId'@'localhost';"
+    mysql -u $productId --password="$mysqlPassword" -e "CREATE database \`$productId\`;"
     
     # Setup installation configuration
     cat > server/config/production.yaml <<EOT

--- a/setup/functions
+++ b/setup/functions
@@ -239,7 +239,7 @@ EOT
 
     (cd client && npm run build)
 
-    chown $userId.$groupId -R .
+    chown $userId:$groupId -R .
 }
 
 


### PR DESCRIPTION
Install script fixes:
- DB name escaped,  'ivis-core' causes error otherwise
- chown invocation with "." changed to ":" as per [recommendation](https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html)