### PR TITLE
Install script fix

### DIFF
--- a/setup/functions
+++ b/setup/functions
@@ -237,6 +237,8 @@ www:
 
 
 mysql:
+  user: "$productId"
+  database: "$productId"
   password: "$mysqlPassword"
 
 redis:


### PR DESCRIPTION
Added user and database to the generated production.yaml server config. The default.yaml server configuration has mysql user and database set to "ivis", while the install script creates the user and database with name equal to $productId (which is "ivis-core" by default).