### PR TITLE
Fix issues #55 and #56

### DIFF
--- a/client/src/ivis/BarChart.js
+++ b/client/src/ivis/BarChart.js
@@ -225,7 +225,12 @@ export class StaticBarChart extends Component {
             .on("zoom", handleZoom)
             .on("end", handleZoomEnd)
             .on("start", handleZoomStart)
-            .wheelDelta(WheelDelta(2));
+            .wheelDelta(WheelDelta(2))
+            .filter(() => {
+                if (d3Event.type === "wheel" && !d3Event.shiftKey)
+                    return false;
+                return !d3Event.ctrlKey && !d3Event.button;
+            });
         this.svgContainerSelection.call(this.zoom);
     }
 

--- a/client/src/ivis/HeatmapChart.js
+++ b/client/src/ivis/HeatmapChart.js
@@ -810,8 +810,9 @@ export class HeatmapChart extends Component {
             .translateExtent(translateExtent)
             .extent(zoomExtent)
             .filter(() => {
-                // noinspection JSUnresolvedVariable
-                return !d3Selection.event.ctrlKey && !d3Selection.event.button && !this.state.brushInProgress;
+                if (d3Event.type === "wheel" && !d3Event.shiftKey)
+                    return false;
+                return !d3Event.ctrlKey && !d3Event.button && !this.state.brushInProgress;
             })
             .on("zoom", handleZoom)
             .on("end", handleZoomEnd)

--- a/client/src/ivis/HistogramChart.js
+++ b/client/src/ivis/HistogramChart.js
@@ -630,7 +630,12 @@ export class HistogramChart extends Component {
             .on("zoom", handleZoom)
             .on("end", handleZoomEnd)
             .on("start", handleZoomStart)
-            .wheelDelta(WheelDelta(2));
+            .wheelDelta(WheelDelta(2))
+            .filter(() => {
+                if (d3Event.type === "wheel" && !d3Event.shiftKey)
+                    return false;
+                return !d3Event.ctrlKey && !d3Event.button;
+            });
         this.svgContainerSelection.call(this.zoom);
         this.moveBrush(this.state.zoomTransform);
     }

--- a/client/src/ivis/ScatterPlotBase.js
+++ b/client/src/ivis/ScatterPlotBase.js
@@ -1670,8 +1670,9 @@ export class ScatterPlotBase extends Component {
             .translateExtent(translateExtent)
             .extent(zoomExtent)
             .filter(() => {
-                // noinspection JSUnresolvedVariable
-                return !d3Selection.event.ctrlKey && !d3Selection.event.button && !this.state.brushInProgress;
+                if (d3Event.type === "wheel" && !d3Event.shiftKey)
+                    return false;
+                return !d3Event.ctrlKey && !d3Event.button && !this.state.brushInProgress;
             })
             .on("zoom", handleZoom)
             .on("end", handleZoomEnd)

--- a/client/src/ivis/TimeBasedChartBase.js
+++ b/client/src/ivis/TimeBasedChartBase.js
@@ -510,7 +510,12 @@ export class TimeBasedChartBase extends Component {
             .on("zoom", handleZoom)
             .on("end", handleZoomEnd)
             .on("start", handleZoomStart)
-            .wheelDelta(WheelDelta(3));
+            .wheelDelta(WheelDelta(3))
+            .filter(() => {
+                if (d3Event.type === "wheel" && !d3Event.shiftKey)
+                    return false;
+                return !d3Event.ctrlKey && !d3Event.button;
+            });
         this.containerNodeSelection.call(this.zoom);
         if (!zoomExisted)
             this.resetZoom(); // this is called after data are reloaded

--- a/client/src/ivis/ViolinPlot.js
+++ b/client/src/ivis/ViolinPlot.js
@@ -814,7 +814,12 @@ export class ViolinPlot extends Component {
             .on("zoom", handleZoom)
             .on("end", handleZoomEnd)
             .on("start", handleZoomStart)
-            .wheelDelta(WheelDelta(2));
+            .wheelDelta(WheelDelta(2))
+            .filter(() => {
+                if (d3Event.type === "wheel" && !d3Event.shiftKey)
+                    return false;
+                return !d3Event.ctrlKey && !d3Event.button;
+            });
         this.svgContainerSelection.call(this.zoom);
     }
 

--- a/client/src/settings/workspaces/panels/CUD.js
+++ b/client/src/settings/workspaces/panels/CUD.js
@@ -108,6 +108,9 @@ export class ImportExportModalDialog extends Component {
             const code = this.props.onExport();
             this.updateFormValue('code', code);
         }
+        else if (prevProps.visible && !this.props.visible) {
+            this.updateFormValue('code', '');
+        }
     }
 
     doImport() {


### PR DESCRIPTION
resolves #55  
resolves #56 

Mouse wheel zoom now only works when shift key is pressed.

I also tried to disable zooming/panning when touch happens on top of an axis on mobile devices to allow better scrolling on phones, but it is not possible. The d3-zoom behavior (the touch events) have to be registered on an HTML element, not on a <rect> or other non-HTML element inside SVG element (otherwise the touch events are not triggered properly). **The only solution for scrolling on phones is currently to have a padding around the chart and drag the screen inside the padding.**